### PR TITLE
Add MCP server for blog post management

### DIFF
--- a/app/Actions/CreateBlogPost.php
+++ b/app/Actions/CreateBlogPost.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\BlogPost;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CreateBlogPost
+{
+    use AsAction;
+
+    public const PLACEHOLDER_FEATURED_IMAGE = 'images/use_case.svg';
+
+    /**
+     * @param  array{
+     *     title_nl: string,
+     *     title_en: string,
+     *     content_nl: string,
+     *     content_en: string,
+     *     excerpt_nl?: string|null,
+     *     excerpt_en?: string|null,
+     *     slug?: string|null,
+     *     featured_image?: string|null,
+     * }  $attributes
+     */
+    public function handle(array $attributes): BlogPost
+    {
+        $slugSource = $attributes['slug'] ?? $attributes['title_nl'];
+
+        return BlogPost::query()->create([
+            'title_nl' => $attributes['title_nl'],
+            'title_en' => $attributes['title_en'],
+            'excerpt_nl' => $attributes['excerpt_nl'] ?? null,
+            'excerpt_en' => $attributes['excerpt_en'] ?? null,
+            'content_nl' => $attributes['content_nl'],
+            'content_en' => $attributes['content_en'],
+            'slug' => GenerateUniqueBlogPostSlug::run($slugSource),
+            'featured_image' => $attributes['featured_image'] ?? self::PLACEHOLDER_FEATURED_IMAGE,
+            'published_at' => null,
+        ]);
+    }
+}

--- a/app/Actions/CreateBlogPost.php
+++ b/app/Actions/CreateBlogPost.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions;
 
+use App\Data\CreateBlogPostData;
 use App\Models\BlogPost;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -11,31 +12,19 @@ class CreateBlogPost
 
     public const PLACEHOLDER_FEATURED_IMAGE = 'images/use_case.svg';
 
-    /**
-     * @param  array{
-     *     title_nl: string,
-     *     title_en: string,
-     *     content_nl: string,
-     *     content_en: string,
-     *     excerpt_nl?: string|null,
-     *     excerpt_en?: string|null,
-     *     slug?: string|null,
-     *     featured_image?: string|null,
-     * }  $attributes
-     */
-    public function handle(array $attributes): BlogPost
+    public function handle(CreateBlogPostData $data): BlogPost
     {
-        $slugSource = $attributes['slug'] ?? $attributes['title_nl'];
+        $slugSource = $data->slug ?? $data->title_nl;
 
         return BlogPost::query()->create([
-            'title_nl' => $attributes['title_nl'],
-            'title_en' => $attributes['title_en'],
-            'excerpt_nl' => $attributes['excerpt_nl'] ?? null,
-            'excerpt_en' => $attributes['excerpt_en'] ?? null,
-            'content_nl' => $attributes['content_nl'],
-            'content_en' => $attributes['content_en'],
+            'title_nl' => $data->title_nl,
+            'title_en' => $data->title_en,
+            'excerpt_nl' => $data->excerpt_nl,
+            'excerpt_en' => $data->excerpt_en,
+            'content_nl' => SanitizeBlogContent::run($data->content_nl),
+            'content_en' => SanitizeBlogContent::run($data->content_en),
             'slug' => GenerateUniqueBlogPostSlug::run($slugSource),
-            'featured_image' => $attributes['featured_image'] ?? self::PLACEHOLDER_FEATURED_IMAGE,
+            'featured_image' => $data->featured_image ?? self::PLACEHOLDER_FEATURED_IMAGE,
             'published_at' => null,
         ]);
     }

--- a/app/Actions/GenerateUniqueBlogPostSlug.php
+++ b/app/Actions/GenerateUniqueBlogPostSlug.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\BlogPost;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GenerateUniqueBlogPostSlug
+{
+    use AsAction;
+
+    public function handle(string $source, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($source);
+        $slug = $base;
+        $suffix = 2;
+
+        while ($this->slugExists($slug, $ignoreId)) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    private function slugExists(string $slug, ?int $ignoreId): bool
+    {
+        return BlogPost::query()
+            ->where('slug', $slug)
+            ->when($ignoreId !== null, fn (Builder $query) => $query->whereKeyNot($ignoreId))
+            ->exists();
+    }
+}

--- a/app/Actions/GetAllBlogPosts.php
+++ b/app/Actions/GetAllBlogPosts.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions;
+
+use App\Data\BlogPostData;
+use App\Models\BlogPost;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Carbon;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetAllBlogPosts
+{
+    use AsAction;
+
+    public const PER_PAGE = 15;
+
+    /**
+     * @param  'all'|'draft'|'published'  $status
+     * @return LengthAwarePaginator<int, array<mixed>>
+     */
+    public function handle(?string $search = null, string $status = 'all', ?int $perPage = null, int $page = 1): LengthAwarePaginator
+    {
+        $perPage ??= self::PER_PAGE;
+
+        $paginator = BlogPost::query()
+            ->when($status === 'published', fn (Builder $query) => $query->published())
+            ->when($status === 'draft', fn (Builder $query) => $this->scopeDraft($query))
+            ->when(is_string($search) && $search !== '', fn (Builder $query) => $this->scopeSearch($query, (string) $search))
+            ->latest()
+            ->paginate(perPage: $perPage, page: $page);
+
+        $items = $paginator->getCollection()->map(
+            fn (BlogPost $blogPost) => BlogPostData::fromModel($blogPost)->toArray()
+        );
+
+        return new LengthAwarePaginator(
+            $items,
+            $paginator->total(),
+            $paginator->perPage(),
+            $paginator->currentPage(),
+        );
+    }
+
+    /**
+     * @param  Builder<BlogPost>  $query
+     * @return Builder<BlogPost>
+     */
+    private function scopeDraft(Builder $query): Builder
+    {
+        return $query->where(fn (Builder $query) => $query
+            ->whereNull('published_at')
+            ->orWhere('published_at', '>', Carbon::now()));
+    }
+
+    /**
+     * @param  Builder<BlogPost>  $query
+     * @return Builder<BlogPost>
+     */
+    private function scopeSearch(Builder $query, string $search): Builder
+    {
+        return $query->where(fn (Builder $query) => $query
+            ->where('title_nl', 'like', "%{$search}%")
+            ->orWhere('title_en', 'like', "%{$search}%"));
+    }
+}

--- a/app/Actions/GetAllBlogPosts.php
+++ b/app/Actions/GetAllBlogPosts.php
@@ -2,11 +2,10 @@
 
 namespace App\Actions;
 
+use App\Builders\BlogPostBuilder;
 use App\Data\BlogPostData;
 use App\Models\BlogPost;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class GetAllBlogPosts
@@ -19,48 +18,24 @@ class GetAllBlogPosts
      * @param  'all'|'draft'|'published'  $status
      * @return LengthAwarePaginator<int, array<mixed>>
      */
-    public function handle(?string $search = null, string $status = 'all', ?int $perPage = null, int $page = 1): LengthAwarePaginator
+    public function handle(?string $search = null, string $status = 'all', ?int $perPage = null, ?int $page = null): LengthAwarePaginator
     {
         $perPage ??= self::PER_PAGE;
 
+        /** @var LengthAwarePaginator<int, array<mixed>> $paginator */
         $paginator = BlogPost::query()
-            ->when($status === 'published', fn (Builder $query) => $query->published())
-            ->when($status === 'draft', fn (Builder $query) => $this->scopeDraft($query))
-            ->when(is_string($search) && $search !== '', fn (Builder $query) => $this->scopeSearch($query, (string) $search))
-            ->latest()
-            ->paginate(perPage: $perPage, page: $page);
+            ->when($status === 'published', fn (BlogPostBuilder $query) => $query->published())
+            ->when($status === 'draft', fn (BlogPostBuilder $query) => $query->draft())
+            ->when(is_string($search) && $search !== '', fn (BlogPostBuilder $query) => $query->search((string) $search))
+            ->when(
+                $status === 'published',
+                fn (BlogPostBuilder $query) => $query->orderByDesc('published_at'),
+                fn (BlogPostBuilder $query) => $query->latest(),
+            )
+            ->paginate(perPage: $perPage, page: $page)
+            ->withQueryString()
+            ->through(fn (BlogPost $blogPost) => BlogPostData::fromModel($blogPost)->toArray());
 
-        $items = $paginator->getCollection()->map(
-            fn (BlogPost $blogPost) => BlogPostData::fromModel($blogPost)->toArray()
-        );
-
-        return new LengthAwarePaginator(
-            $items,
-            $paginator->total(),
-            $paginator->perPage(),
-            $paginator->currentPage(),
-        );
-    }
-
-    /**
-     * @param  Builder<BlogPost>  $query
-     * @return Builder<BlogPost>
-     */
-    private function scopeDraft(Builder $query): Builder
-    {
-        return $query->where(fn (Builder $query) => $query
-            ->whereNull('published_at')
-            ->orWhere('published_at', '>', Carbon::now()));
-    }
-
-    /**
-     * @param  Builder<BlogPost>  $query
-     * @return Builder<BlogPost>
-     */
-    private function scopeSearch(Builder $query, string $search): Builder
-    {
-        return $query->where(fn (Builder $query) => $query
-            ->where('title_nl', 'like', "%{$search}%")
-            ->orWhere('title_en', 'like', "%{$search}%"));
+        return $paginator;
     }
 }

--- a/app/Actions/GetPublishedBlogPosts.php
+++ b/app/Actions/GetPublishedBlogPosts.php
@@ -2,8 +2,6 @@
 
 namespace App\Actions;
 
-use App\Data\BlogPostData;
-use App\Models\BlogPost;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -18,26 +16,6 @@ class GetPublishedBlogPosts
      */
     public function handle(?int $perPage = null): LengthAwarePaginator
     {
-        $perPage ??= self::PER_PAGE;
-
-        $queryPaginator = BlogPost::query()
-            ->published()
-            ->orderByDesc('published_at')
-            ->paginate($perPage);
-
-        $items = $queryPaginator->getCollection()->map(
-            fn (BlogPost $blogPost) => BlogPostData::fromModel($blogPost)->toArray()
-        );
-
-        return (new LengthAwarePaginator(
-            $items,
-            $queryPaginator->total(),
-            $queryPaginator->perPage(),
-            $queryPaginator->currentPage(),
-            [
-                'path' => $queryPaginator->path(),
-                'pageName' => $queryPaginator->getPageName(),
-            ],
-        ))->withQueryString();
+        return GetAllBlogPosts::run(status: 'published', perPage: $perPage ?? self::PER_PAGE);
     }
 }

--- a/app/Actions/PublishBlogPost.php
+++ b/app/Actions/PublishBlogPost.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\BlogPost;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class PublishBlogPost
+{
+    use AsAction;
+
+    public function handle(BlogPost $blogPost, ?CarbonInterface $publishedAt = null): BlogPost
+    {
+        $blogPost->published_at = $publishedAt ?? Carbon::now();
+        $blogPost->save();
+
+        return $blogPost;
+    }
+}

--- a/app/Actions/SanitizeBlogContent.php
+++ b/app/Actions/SanitizeBlogContent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Actions;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use Mews\Purifier\Facades\Purifier;
+
+class SanitizeBlogContent
+{
+    use AsAction;
+
+    public function handle(string $html): string
+    {
+        return Purifier::clean($html);
+    }
+}

--- a/app/Actions/UnpublishBlogPost.php
+++ b/app/Actions/UnpublishBlogPost.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\BlogPost;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UnpublishBlogPost
+{
+    use AsAction;
+
+    public function handle(BlogPost $blogPost): BlogPost
+    {
+        $blogPost->published_at = null;
+        $blogPost->save();
+
+        return $blogPost;
+    }
+}

--- a/app/Actions/UpdateBlogPost.php
+++ b/app/Actions/UpdateBlogPost.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\BlogPost;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UpdateBlogPost
+{
+    use AsAction;
+
+    /**
+     * Applies a partial (patch) update: only the provided keys are changed.
+     *
+     * @param  array{
+     *     title_nl?: string,
+     *     title_en?: string,
+     *     content_nl?: string,
+     *     content_en?: string,
+     *     excerpt_nl?: string|null,
+     *     excerpt_en?: string|null,
+     *     slug?: string,
+     *     featured_image?: string,
+     * }  $attributes
+     */
+    public function handle(BlogPost $blogPost, array $attributes): BlogPost
+    {
+        if (array_key_exists('slug', $attributes)) {
+            $attributes['slug'] = GenerateUniqueBlogPostSlug::run($attributes['slug'], $blogPost->id);
+        }
+
+        $blogPost->fill($attributes)->save();
+
+        return $blogPost->refresh();
+    }
+}

--- a/app/Actions/UpdateBlogPost.php
+++ b/app/Actions/UpdateBlogPost.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions;
 
+use App\Data\UpdateBlogPostData;
 use App\Models\BlogPost;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -10,23 +11,21 @@ class UpdateBlogPost
     use AsAction;
 
     /**
-     * Applies a partial (patch) update: only the provided keys are changed.
-     *
-     * @param  array{
-     *     title_nl?: string,
-     *     title_en?: string,
-     *     content_nl?: string,
-     *     content_en?: string,
-     *     excerpt_nl?: string|null,
-     *     excerpt_en?: string|null,
-     *     slug?: string,
-     *     featured_image?: string,
-     * }  $attributes
+     * Applies a partial (patch) update: only the fields present on the data
+     * object are changed, the rest are left untouched.
      */
-    public function handle(BlogPost $blogPost, array $attributes): BlogPost
+    public function handle(BlogPost $blogPost, UpdateBlogPostData $data): BlogPost
     {
+        $attributes = $data->toArray();
+
         if (array_key_exists('slug', $attributes)) {
             $attributes['slug'] = GenerateUniqueBlogPostSlug::run($attributes['slug'], $blogPost->id);
+        }
+
+        foreach (['content_nl', 'content_en'] as $field) {
+            if (isset($attributes[$field]) && is_string($attributes[$field])) {
+                $attributes[$field] = SanitizeBlogContent::run($attributes[$field]);
+            }
         }
 
         $blogPost->fill($attributes)->save();

--- a/app/Builders/BlogPostBuilder.php
+++ b/app/Builders/BlogPostBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Builders;
+
+use App\Models\BlogPost;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Builder<BlogPost>
+ */
+class BlogPostBuilder extends Builder
+{
+    public function published(): self
+    {
+        return $this
+            ->whereNotNull('published_at')
+            ->where('published_at', '<=', Carbon::now());
+    }
+
+    public function draft(): self
+    {
+        return $this->where(function (Builder $query): void {
+            $query
+                ->whereNull('published_at')
+                ->orWhere('published_at', '>', Carbon::now());
+        });
+    }
+
+    public function search(string $term): self
+    {
+        return $this->where(function (Builder $query) use ($term): void {
+            $query
+                ->where('title_nl', 'like', "%{$term}%")
+                ->orWhere('title_en', 'like', "%{$term}%");
+        });
+    }
+}

--- a/app/Console/Commands/IssueBlogTokenCommand.php
+++ b/app/Console/Commands/IssueBlogTokenCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\BlogAbility;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class IssueBlogTokenCommand extends Command
+{
+    protected $signature = 'mcp:issue-blog-token
+        {--email=agents@mecctech-solutions.nl : Email of the agent service account}
+        {--name=MCP Agent : Name used when the service account is created}
+        {--token-name=claude-code : Label for the issued token}';
+
+    protected $description = 'Issue a Sanctum token for the blog MCP server, creating the agent service account if needed';
+
+    public function handle(): int
+    {
+        $email = (string) $this->option('email');
+
+        $user = User::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => (string) $this->option('name'),
+                'password' => Hash::make(Str::random(40)),
+            ],
+        );
+
+        $abilities = array_map(fn (BlogAbility $ability): string => $ability->value, BlogAbility::cases());
+
+        $token = $user->createToken((string) $this->option('token-name'), $abilities)->plainTextToken;
+
+        $this->info("Token issued for {$email} with abilities: ".implode(', ', $abilities));
+        $this->newLine();
+        $this->line($token);
+        $this->newLine();
+        $this->comment('Copy the token now — it will not be shown again.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Data/CreateBlogPostData.php
+++ b/app/Data/CreateBlogPostData.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+
+class CreateBlogPostData extends Data
+{
+    public function __construct(
+        public string $title_nl,
+        public string $title_en,
+        public string $content_nl,
+        public string $content_en,
+        public ?string $excerpt_nl = null,
+        public ?string $excerpt_en = null,
+        public ?string $slug = null,
+        public ?string $featured_image = null,
+    ) {}
+}

--- a/app/Data/UpdateBlogPostData.php
+++ b/app/Data/UpdateBlogPostData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
+
+class UpdateBlogPostData extends Data
+{
+    public function __construct(
+        public string|Optional $title_nl,
+        public string|Optional $title_en,
+        public string|Optional $content_nl,
+        public string|Optional $content_en,
+        public string|null|Optional $excerpt_nl,
+        public string|null|Optional $excerpt_en,
+        public string|Optional $slug,
+        public string|Optional $featured_image,
+    ) {}
+}

--- a/app/Enums/BlogAbility.php
+++ b/app/Enums/BlogAbility.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum BlogAbility: string
+{
+    case Read = 'blog:read';
+    case Write = 'blog:write';
+}

--- a/app/Filament/Resources/BlogPostResource.php
+++ b/app/Filament/Resources/BlogPostResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Builders\BlogPostBuilder;
 use App\Filament\Resources\BlogPostResource\Pages;
 use App\Models\BlogPost;
 use Filament\Forms;
@@ -84,13 +85,10 @@ class BlogPostResource extends Resource
             ->filters([
                 Tables\Filters\Filter::make('published')
                     ->label('Published')
-                    ->query(fn ($query) => $query->published()),
+                    ->query(fn (BlogPostBuilder $query) => $query->published()),
                 Tables\Filters\Filter::make('draft')
                     ->label('Draft')
-                    ->query(fn ($query) => $query->where(function ($q) {
-                        $q->whereNull('published_at')
-                            ->orWhere('published_at', '>', now());
-                    })),
+                    ->query(fn (BlogPostBuilder $query) => $query->draft()),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Http/Requests/Mcp/CreateBlogPostRequest.php
+++ b/app/Http/Requests/Mcp/CreateBlogPostRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class CreateBlogPostRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title_nl' => ['required', 'string', 'max:255'],
+            'title_en' => ['required', 'string', 'max:255'],
+            'content_nl' => ['required', 'string'],
+            'content_en' => ['required', 'string'],
+            'excerpt_nl' => ['nullable', 'string'],
+            'excerpt_en' => ['nullable', 'string'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'featured_image' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Mcp/GetBlogPostRequest.php
+++ b/app/Http/Requests/Mcp/GetBlogPostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class GetBlogPostRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Mcp/ListBlogPostsRequest.php
+++ b/app/Http/Requests/Mcp/ListBlogPostsRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class ListBlogPostsRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'search' => ['nullable', 'string'],
+            'status' => ['nullable', 'in:all,draft,published'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Mcp/McpFormRequest.php
+++ b/app/Http/Requests/Mcp/McpFormRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+abstract class McpFormRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    abstract public function rules(): array;
+}

--- a/app/Http/Requests/Mcp/PublishBlogPostRequest.php
+++ b/app/Http/Requests/Mcp/PublishBlogPostRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class PublishBlogPostRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+            'published_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Mcp/UnpublishBlogPostRequest.php
+++ b/app/Http/Requests/Mcp/UnpublishBlogPostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class UnpublishBlogPostRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Mcp/UpdateBlogPostRequest.php
+++ b/app/Http/Requests/Mcp/UpdateBlogPostRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Mcp;
+
+class UpdateBlogPostRequest extends McpFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+            'title_nl' => ['sometimes', 'string', 'max:255'],
+            'title_en' => ['sometimes', 'string', 'max:255'],
+            'content_nl' => ['sometimes', 'string'],
+            'content_en' => ['sometimes', 'string'],
+            'excerpt_nl' => ['sometimes', 'nullable', 'string'],
+            'excerpt_en' => ['sometimes', 'nullable', 'string'],
+            'slug' => ['sometimes', 'string', 'max:255'],
+            'featured_image' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Mcp/Concerns/HandlesBlogToolRequests.php
+++ b/app/Mcp/Concerns/HandlesBlogToolRequests.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mcp\Concerns;
+
+use Illuminate\Support\Facades\Validator;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+trait HandlesBlogToolRequests
+{
+    protected function missingAbility(string $ability): ?ToolResult
+    {
+        if (request()->user()?->tokenCan($ability)) {
+            return null;
+        }
+
+        return ToolResult::error("The authenticated token is missing the required '{$ability}' ability.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $rules
+     * @return array<string, mixed>|ToolResult
+     */
+    protected function validateArguments(array $arguments, array $rules): array|ToolResult
+    {
+        $validator = Validator::make($arguments, $rules);
+
+        if ($validator->fails()) {
+            return ToolResult::error($validator->errors()->toJson());
+        }
+
+        return $validator->validated();
+    }
+}

--- a/app/Mcp/Concerns/HandlesBlogToolRequests.php
+++ b/app/Mcp/Concerns/HandlesBlogToolRequests.php
@@ -2,28 +2,29 @@
 
 namespace App\Mcp\Concerns;
 
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\McpFormRequest;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Mcp\Server\Tools\ToolResult;
 
 trait HandlesBlogToolRequests
 {
-    protected function missingAbility(string $ability): ?ToolResult
+    protected function missingAbility(BlogAbility $ability): ?ToolResult
     {
-        if (request()->user()?->tokenCan($ability)) {
+        if (request()->user()?->tokenCan($ability->value)) {
             return null;
         }
 
-        return ToolResult::error("The authenticated token is missing the required '{$ability}' ability.");
+        return ToolResult::error("The authenticated token is missing the required '{$ability->value}' ability.");
     }
 
     /**
      * @param  array<string, mixed>  $arguments
-     * @param  array<string, mixed>  $rules
      * @return array<string, mixed>|ToolResult
      */
-    protected function validateArguments(array $arguments, array $rules): array|ToolResult
+    protected function validateArguments(array $arguments, McpFormRequest $request): array|ToolResult
     {
-        $validator = Validator::make($arguments, $rules);
+        $validator = Validator::make($arguments, $request->rules());
 
         if ($validator->fails()) {
             return ToolResult::error($validator->errors()->toJson());

--- a/app/Mcp/Servers/BlogServer.php
+++ b/app/Mcp/Servers/BlogServer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\CreateBlogPost;
+use App\Mcp\Tools\GetBlogPost;
+use App\Mcp\Tools\ListBlogPosts;
+use App\Mcp\Tools\PublishBlogPost;
+use App\Mcp\Tools\UnpublishBlogPost;
+use App\Mcp\Tools\UpdateBlogPost;
+use Laravel\Mcp\Server;
+
+class BlogServer extends Server
+{
+    public string $serverName = 'Blog Server';
+
+    public string $serverVersion = '0.0.1';
+
+    public string $instructions = 'Manage blog posts on the MeccTech Solutions website. '
+        .'Every post is bilingual: always provide both Dutch (nl) and English (en) title and content. '
+        .'Newly created posts are drafts; use publish-blog-post to make them live and unpublish-blog-post '
+        .'to revert them to draft. Deleting posts is intentionally not supported.';
+
+    public array $tools = [
+        CreateBlogPost::class,
+        UpdateBlogPost::class,
+        GetBlogPost::class,
+        ListBlogPosts::class,
+        PublishBlogPost::class,
+        UnpublishBlogPost::class,
+    ];
+
+    public array $resources = [];
+
+    public array $prompts = [];
+}

--- a/app/Mcp/Tools/CreateBlogPost.php
+++ b/app/Mcp/Tools/CreateBlogPost.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Actions\CreateBlogPost as CreateBlogPostAction;
+use App\Data\BlogPostData;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use Generator;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('Create Blog Post')]
+class CreateBlogPost extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'Create a new blog post as a draft. Provide both Dutch (nl) and English (en) content; '
+            .'the post is created unpublished, use publish-blog-post to make it live. '
+            .'The slug is generated automatically from title_nl unless provided, and featured_image '
+            .'falls back to a placeholder when omitted.';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->string('title_nl')->description('Dutch title.')->required();
+        $schema->string('title_en')->description('English title.')->required();
+        $schema->string('content_nl')->description('Dutch body (HTML).')->required();
+        $schema->string('content_en')->description('English body (HTML).')->required();
+        $schema->string('excerpt_nl')->description('Optional Dutch excerpt.');
+        $schema->string('excerpt_en')->description('Optional English excerpt.');
+        $schema->string('slug')->description('Optional URL slug; auto-generated from title_nl when omitted.');
+        $schema->string('featured_image')->description('Optional path to an existing image on the public disk.');
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:write')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'title_nl' => ['required', 'string', 'max:255'],
+            'title_en' => ['required', 'string', 'max:255'],
+            'content_nl' => ['required', 'string'],
+            'content_en' => ['required', 'string'],
+            'excerpt_nl' => ['nullable', 'string'],
+            'excerpt_en' => ['nullable', 'string'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'featured_image' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $blogPost = CreateBlogPostAction::run($validated);
+
+        return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
+    }
+}

--- a/app/Mcp/Tools/CreateBlogPost.php
+++ b/app/Mcp/Tools/CreateBlogPost.php
@@ -4,6 +4,9 @@ namespace App\Mcp\Tools;
 
 use App\Actions\CreateBlogPost as CreateBlogPostAction;
 use App\Data\BlogPostData;
+use App\Data\CreateBlogPostData;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\CreateBlogPostRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use Generator;
 use Laravel\Mcp\Server\Tool;
@@ -43,26 +46,17 @@ class CreateBlogPost extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:write')) {
+        if ($missing = $this->missingAbility(BlogAbility::Write)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'title_nl' => ['required', 'string', 'max:255'],
-            'title_en' => ['required', 'string', 'max:255'],
-            'content_nl' => ['required', 'string'],
-            'content_en' => ['required', 'string'],
-            'excerpt_nl' => ['nullable', 'string'],
-            'excerpt_en' => ['nullable', 'string'],
-            'slug' => ['nullable', 'string', 'max:255'],
-            'featured_image' => ['nullable', 'string', 'max:255'],
-        ]);
+        $validated = $this->validateArguments($arguments, new CreateBlogPostRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;
         }
 
-        $blogPost = CreateBlogPostAction::run($validated);
+        $blogPost = CreateBlogPostAction::run(CreateBlogPostData::from($validated));
 
         return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
     }

--- a/app/Mcp/Tools/GetBlogPost.php
+++ b/app/Mcp/Tools/GetBlogPost.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Data\BlogPostData;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use App\Models\BlogPost;
+use Generator;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('Get Blog Post')]
+class GetBlogPost extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'Fetch a single blog post by id, including drafts. Returns both language versions '
+            .'and the publication status (published_at is null when the post is a draft).';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->integer('id')->description('The id of the blog post to fetch.')->required();
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:read')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $blogPost = BlogPost::query()->findOrFail((int) $validated['id']);
+
+        return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
+    }
+}

--- a/app/Mcp/Tools/GetBlogPost.php
+++ b/app/Mcp/Tools/GetBlogPost.php
@@ -3,6 +3,8 @@
 namespace App\Mcp\Tools;
 
 use App\Data\BlogPostData;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\GetBlogPostRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use App\Models\BlogPost;
 use Generator;
@@ -34,13 +36,11 @@ class GetBlogPost extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:read')) {
+        if ($missing = $this->missingAbility(BlogAbility::Read)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'id' => ['required', 'integer', 'exists:blog_posts,id'],
-        ]);
+        $validated = $this->validateArguments($arguments, new GetBlogPostRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;

--- a/app/Mcp/Tools/ListBlogPosts.php
+++ b/app/Mcp/Tools/ListBlogPosts.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Actions\GetAllBlogPosts;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use Generator;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('List Blog Posts')]
+class ListBlogPosts extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'List blog posts (including drafts) with pagination. Optionally filter by status '
+            .'(all, draft, published) and search on the Dutch or English title. Returns a paginated '
+            .'result with data and pagination metadata (current_page, last_page, total, per_page).';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->string('search')->description('Optional search term matched against title_nl and title_en.');
+        $schema->string('status')->description('Filter by status: all (default), draft, or published.');
+        $schema->integer('page')->description('Page number, defaults to 1.');
+        $schema->integer('per_page')->description('Results per page (1-100), defaults to 15.');
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:read')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'search' => ['nullable', 'string'],
+            'status' => ['nullable', 'in:all,draft,published'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $paginator = GetAllBlogPosts::run(
+            $validated['search'] ?? null,
+            $validated['status'] ?? 'all',
+            $validated['per_page'] ?? null,
+            $validated['page'] ?? 1,
+        );
+
+        return ToolResult::json($paginator->toArray());
+    }
+}

--- a/app/Mcp/Tools/ListBlogPosts.php
+++ b/app/Mcp/Tools/ListBlogPosts.php
@@ -3,6 +3,8 @@
 namespace App\Mcp\Tools;
 
 use App\Actions\GetAllBlogPosts;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\ListBlogPostsRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use Generator;
 use Laravel\Mcp\Server\Tool;
@@ -37,16 +39,11 @@ class ListBlogPosts extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:read')) {
+        if ($missing = $this->missingAbility(BlogAbility::Read)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'search' => ['nullable', 'string'],
-            'status' => ['nullable', 'in:all,draft,published'],
-            'page' => ['nullable', 'integer', 'min:1'],
-            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
-        ]);
+        $validated = $this->validateArguments($arguments, new ListBlogPostsRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;
@@ -56,7 +53,7 @@ class ListBlogPosts extends Tool
             $validated['search'] ?? null,
             $validated['status'] ?? 'all',
             $validated['per_page'] ?? null,
-            $validated['page'] ?? 1,
+            $validated['page'] ?? null,
         );
 
         return ToolResult::json($paginator->toArray());

--- a/app/Mcp/Tools/PublishBlogPost.php
+++ b/app/Mcp/Tools/PublishBlogPost.php
@@ -4,6 +4,8 @@ namespace App\Mcp\Tools;
 
 use App\Actions\PublishBlogPost as PublishBlogPostAction;
 use App\Data\BlogPostData;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\PublishBlogPostRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use App\Models\BlogPost;
 use Generator;
@@ -37,14 +39,11 @@ class PublishBlogPost extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:write')) {
+        if ($missing = $this->missingAbility(BlogAbility::Write)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'id' => ['required', 'integer', 'exists:blog_posts,id'],
-            'published_at' => ['nullable', 'date'],
-        ]);
+        $validated = $this->validateArguments($arguments, new PublishBlogPostRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;

--- a/app/Mcp/Tools/PublishBlogPost.php
+++ b/app/Mcp/Tools/PublishBlogPost.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Actions\PublishBlogPost as PublishBlogPostAction;
+use App\Data\BlogPostData;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use App\Models\BlogPost;
+use Generator;
+use Illuminate\Support\Carbon;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('Publish Blog Post')]
+class PublishBlogPost extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'Publish a blog post by id. Without published_at the post goes live immediately; '
+            .'provide a future ISO 8601 published_at to schedule it to go live at that moment.';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->integer('id')->description('The id of the blog post to publish.')->required();
+        $schema->string('published_at')->description('Optional ISO 8601 datetime; defaults to now. A future value schedules publication.');
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:write')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+            'published_at' => ['nullable', 'date'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $blogPost = BlogPost::query()->findOrFail((int) $validated['id']);
+
+        $publishedAt = isset($validated['published_at'])
+            ? Carbon::parse($validated['published_at'])
+            : null;
+
+        $blogPost = PublishBlogPostAction::run($blogPost, $publishedAt);
+
+        return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
+    }
+}

--- a/app/Mcp/Tools/UnpublishBlogPost.php
+++ b/app/Mcp/Tools/UnpublishBlogPost.php
@@ -4,6 +4,8 @@ namespace App\Mcp\Tools;
 
 use App\Actions\UnpublishBlogPost as UnpublishBlogPostAction;
 use App\Data\BlogPostData;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\UnpublishBlogPostRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use App\Models\BlogPost;
 use Generator;
@@ -35,13 +37,11 @@ class UnpublishBlogPost extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:write')) {
+        if ($missing = $this->missingAbility(BlogAbility::Write)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'id' => ['required', 'integer', 'exists:blog_posts,id'],
-        ]);
+        $validated = $this->validateArguments($arguments, new UnpublishBlogPostRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;

--- a/app/Mcp/Tools/UnpublishBlogPost.php
+++ b/app/Mcp/Tools/UnpublishBlogPost.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Actions\UnpublishBlogPost as UnpublishBlogPostAction;
+use App\Data\BlogPostData;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use App\Models\BlogPost;
+use Generator;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('Unpublish Blog Post')]
+class UnpublishBlogPost extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'Unpublish a blog post by id, reverting it to a draft by clearing its published_at. '
+            .'The post is removed from the public site but its content is kept.';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->integer('id')->description('The id of the blog post to unpublish.')->required();
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:write')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $blogPost = BlogPost::query()->findOrFail((int) $validated['id']);
+
+        $blogPost = UnpublishBlogPostAction::run($blogPost);
+
+        return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
+    }
+}

--- a/app/Mcp/Tools/UpdateBlogPost.php
+++ b/app/Mcp/Tools/UpdateBlogPost.php
@@ -4,6 +4,9 @@ namespace App\Mcp\Tools;
 
 use App\Actions\UpdateBlogPost as UpdateBlogPostAction;
 use App\Data\BlogPostData;
+use App\Data\UpdateBlogPostData;
+use App\Enums\BlogAbility;
+use App\Http\Requests\Mcp\UpdateBlogPostRequest;
 use App\Mcp\Concerns\HandlesBlogToolRequests;
 use App\Models\BlogPost;
 use Generator;
@@ -45,30 +48,22 @@ class UpdateBlogPost extends Tool
      */
     public function handle(array $arguments): ToolResult|Generator
     {
-        if ($missing = $this->missingAbility('blog:write')) {
+        if ($missing = $this->missingAbility(BlogAbility::Write)) {
             return $missing;
         }
 
-        $validated = $this->validateArguments($arguments, [
-            'id' => ['required', 'integer', 'exists:blog_posts,id'],
-            'title_nl' => ['sometimes', 'string', 'max:255'],
-            'title_en' => ['sometimes', 'string', 'max:255'],
-            'content_nl' => ['sometimes', 'string'],
-            'content_en' => ['sometimes', 'string'],
-            'excerpt_nl' => ['sometimes', 'nullable', 'string'],
-            'excerpt_en' => ['sometimes', 'nullable', 'string'],
-            'slug' => ['sometimes', 'string', 'max:255'],
-            'featured_image' => ['sometimes', 'string', 'max:255'],
-        ]);
+        $validated = $this->validateArguments($arguments, new UpdateBlogPostRequest);
 
         if ($validated instanceof ToolResult) {
             return $validated;
         }
 
         $blogPost = BlogPost::query()->findOrFail((int) $validated['id']);
-        $attributes = Arr::except($validated, ['id']);
 
-        $blogPost = UpdateBlogPostAction::run($blogPost, $attributes);
+        $blogPost = UpdateBlogPostAction::run(
+            $blogPost,
+            UpdateBlogPostData::from(Arr::except($validated, ['id'])),
+        );
 
         return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
     }

--- a/app/Mcp/Tools/UpdateBlogPost.php
+++ b/app/Mcp/Tools/UpdateBlogPost.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Actions\UpdateBlogPost as UpdateBlogPostAction;
+use App\Data\BlogPostData;
+use App\Mcp\Concerns\HandlesBlogToolRequests;
+use App\Models\BlogPost;
+use Generator;
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\Title;
+use Laravel\Mcp\Server\Tools\ToolInputSchema;
+use Laravel\Mcp\Server\Tools\ToolResult;
+
+#[Title('Update Blog Post')]
+class UpdateBlogPost extends Tool
+{
+    use HandlesBlogToolRequests;
+
+    public function description(): string
+    {
+        return 'Update the content of an existing blog post identified by id. This is a partial (patch) '
+            .'update: only the fields you provide are changed, the rest are left untouched. '
+            .'Publication status is not changed here; use publish-blog-post or unpublish-blog-post for that.';
+    }
+
+    public function schema(ToolInputSchema $schema): ToolInputSchema
+    {
+        $schema->integer('id')->description('The id of the blog post to update.')->required();
+        $schema->string('title_nl')->description('Dutch title.');
+        $schema->string('title_en')->description('English title.');
+        $schema->string('content_nl')->description('Dutch body (HTML).');
+        $schema->string('content_en')->description('English body (HTML).');
+        $schema->string('excerpt_nl')->description('Dutch excerpt.');
+        $schema->string('excerpt_en')->description('English excerpt.');
+        $schema->string('slug')->description('URL slug; re-checked for uniqueness when provided.');
+        $schema->string('featured_image')->description('Path to an existing image on the public disk.');
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function handle(array $arguments): ToolResult|Generator
+    {
+        if ($missing = $this->missingAbility('blog:write')) {
+            return $missing;
+        }
+
+        $validated = $this->validateArguments($arguments, [
+            'id' => ['required', 'integer', 'exists:blog_posts,id'],
+            'title_nl' => ['sometimes', 'string', 'max:255'],
+            'title_en' => ['sometimes', 'string', 'max:255'],
+            'content_nl' => ['sometimes', 'string'],
+            'content_en' => ['sometimes', 'string'],
+            'excerpt_nl' => ['sometimes', 'nullable', 'string'],
+            'excerpt_en' => ['sometimes', 'nullable', 'string'],
+            'slug' => ['sometimes', 'string', 'max:255'],
+            'featured_image' => ['sometimes', 'string', 'max:255'],
+        ]);
+
+        if ($validated instanceof ToolResult) {
+            return $validated;
+        }
+
+        $blogPost = BlogPost::query()->findOrFail((int) $validated['id']);
+        $attributes = Arr::except($validated, ['id']);
+
+        $blogPost = UpdateBlogPostAction::run($blogPost, $attributes);
+
+        return ToolResult::json(BlogPostData::fromModel($blogPost)->toArray());
+    }
+}

--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -2,11 +2,12 @@
 
 namespace App\Models;
 
+use App\Builders\BlogPostBuilder;
 use Carbon\CarbonInterface;
 use Database\Factories\BlogPostFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 
 /**
  * @property CarbonInterface|null $published_at
@@ -44,14 +45,11 @@ class BlogPost extends Model
     }
 
     /**
-     * @param  Builder<static>  $query
-     * @return Builder<static>
+     * @param  Builder  $query
      */
-    public function scopePublished(Builder $query): Builder
+    public function newEloquentBuilder($query): BlogPostBuilder
     {
-        return $query
-            ->whereNotNull('published_at')
-            ->where('published_at', '<=', now());
+        return new BlogPostBuilder($query);
     }
 
     protected static function newFactory(): BlogPostFactory

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "lorisleiva/laravel-actions": "^2.8",
         "maatwebsite/excel": "^3.1",
         "mariuzzo/laravel-js-localization": "^1.11",
+        "mews/purifier": "^3.4",
         "phpoffice/phpexcel": "^1.8",
         "phpoffice/phpspreadsheet": "^1.22",
         "spatie/eloquent-sortable": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^11.0",
+        "laravel/mcp": "^0.1.1",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.5",
         "laravel/ui": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1c9d4c4c87a5ec9bfc9e9b3430816b1",
+    "content-hash": "69f88b3bffa37a5b3e8df3c22b841567",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3735,6 +3735,70 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2025-06-03T14:01:40+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/6d6284a491f07c74d34f48dfd999ed52c567c713",
+                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0",
+                "php": "^8.1|^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "orchestra/testbench": "^8.22.0|^9.0|^10.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Workbench\\App\\": "workbench/app/",
+                    "Laravel\\Mcp\\Tests\\": "tests/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The easiest way to add MCP servers to your Laravel app.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "dev",
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2025-08-16T09:50:43+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -13096,70 +13160,6 @@
                 "source": "https://github.com/laravel/dusk/tree/v8.3.2"
             },
             "time": "2025-02-20T14:42:00+00:00"
-        },
-        {
-            "name": "laravel/mcp",
-            "version": "v0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/mcp.git",
-                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/6d6284a491f07c74d34f48dfd999ed52c567c713",
-                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/console": "^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^10.0|^11.0|^12.0",
-                "illuminate/http": "^10.0|^11.0|^12.0",
-                "illuminate/routing": "^10.0|^11.0|^12.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
-                "illuminate/validation": "^10.0|^11.0|^12.0",
-                "php": "^8.1|^8.2"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.14",
-                "orchestra/testbench": "^8.22.0|^9.0|^10.0",
-                "phpstan/phpstan": "^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
-                    },
-                    "providers": [
-                        "Laravel\\Mcp\\Server\\McpServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\Mcp\\": "src/",
-                    "Workbench\\App\\": "workbench/app/",
-                    "Laravel\\Mcp\\Tests\\": "tests/",
-                    "Laravel\\Mcp\\Server\\": "src/Server/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The easiest way to add MCP servers to your Laravel app.",
-            "homepage": "https://github.com/laravel/mcp",
-            "keywords": [
-                "dev",
-                "laravel",
-                "mcp"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/mcp/issues",
-                "source": "https://github.com/laravel/mcp"
-            },
-            "time": "2025-08-16T09:50:43+00:00"
         },
         {
             "name": "laravel/roster",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69f88b3bffa37a5b3e8df3c22b841567",
+    "content-hash": "9e99c5e7f07dee65bdf35c0299c6e56a",
     "packages": [
         {
             "name": "amphp/amp",
@@ -5511,6 +5511,84 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
             },
             "time": "2024-03-31T07:05:07+00:00"
+        },
+        {
+            "name": "mews/purifier",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mewebstudio/Purifier.git",
+                "reference": "b2705cc6c832ce7229373418e191d71b6c037841"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mewebstudio/Purifier/zipball/b2705cc6c832ce7229373418e191d71b6c037841",
+                "reference": "b2705cc6c832ce7229373418e191d71b6c037841",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.16.0",
+                "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "graham-campbell/testbench": "^3.2|^5.5.1|^6.1",
+                "mockery/mockery": "^1.3.3",
+                "phpunit/phpunit": "^8.0|^9.0|^10.0"
+            },
+            "suggest": {
+                "laravel/framework": "To test the Laravel bindings",
+                "laravel/lumen-framework": "To test the Lumen bindings"
+            },
+            "type": "package",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Purifier": "Mews\\Purifier\\Facades\\Purifier"
+                    },
+                    "providers": [
+                        "Mews\\Purifier\\PurifierServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Mews\\Purifier\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muharrem ERİN",
+                    "email": "me@mewebstudio.com",
+                    "homepage": "https://github.com/mewebstudio",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5/6/7/8/9/10 HtmlPurifier Package",
+            "homepage": "https://github.com/mewebstudio/purifier",
+            "keywords": [
+                "Laravel Purifier",
+                "Laravel Security",
+                "Purifier",
+                "htmlpurifier",
+                "laravel HtmlPurifier",
+                "security",
+                "xss"
+            ],
+            "support": {
+                "issues": "https://github.com/mewebstudio/Purifier/issues",
+                "source": "https://github.com/mewebstudio/Purifier/tree/3.4.4"
+            },
+            "time": "2026-04-15T16:41:08+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -33,6 +33,16 @@ phone_number: string;
 message: string;
 company: string | null;
 };
+export type CreateBlogPostData = {
+title_nl: string;
+title_en: string;
+content_nl: string;
+content_en: string;
+excerpt_nl: string | null;
+excerpt_en: string | null;
+slug: string | null;
+featured_image: string | null;
+};
 export type ImageData = {
 full_url: string;
 url: string;
@@ -71,7 +81,18 @@ image_full_url: string;
 position: number;
 client_name: string | null;
 };
+export type UpdateBlogPostData = {
+title_nl?: string;
+title_en?: string;
+content_nl?: string;
+content_en?: string;
+excerpt_nl?: string | null;
+excerpt_en?: string | null;
+slug?: string;
+featured_image?: string;
+};
 }
 declare namespace App.Enums {
+export type BlogAbility = 'blog:read' | 'blog:write';
 export type SettingKey = 'portfolio_items.items_per_page';
 }

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Mcp\Servers\BlogServer;
+use Laravel\Mcp\Server\Facades\Mcp;
+
+Mcp::web('blog', BlogServer::class)
+    ->middleware('auth:sanctum');

--- a/tests/Feature/Actions/CreateBlogPostTest.php
+++ b/tests/Feature/Actions/CreateBlogPostTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Actions\CreateBlogPost;
+use App\Models\BlogPost;
+
+it('creates a blog post as a draft', function () {
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Nederlandse titel',
+        'title_en' => 'English title',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    expect($blogPost)->toBeInstanceOf(BlogPost::class)
+        ->and($blogPost->published_at)->toBeNull()
+        ->and($blogPost->title_nl)->toBe('Nederlandse titel')
+        ->and($blogPost->title_en)->toBe('English title');
+});
+
+it('generates a slug from the dutch title when none is provided', function () {
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Mijn Eerste Post',
+        'title_en' => 'My First Post',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    expect($blogPost->slug)->toBe('mijn-eerste-post');
+});
+
+it('appends a suffix when the generated slug already exists', function () {
+    BlogPost::factory()->create(['slug' => 'mijn-eerste-post']);
+
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Mijn Eerste Post',
+        'title_en' => 'My First Post',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    expect($blogPost->slug)->toBe('mijn-eerste-post-2');
+});
+
+it('uses the provided slug when given', function () {
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Nederlandse titel',
+        'title_en' => 'English title',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+        'slug' => 'custom-slug',
+    ]);
+
+    expect($blogPost->slug)->toBe('custom-slug');
+});
+
+it('falls back to the placeholder featured image when none is provided', function () {
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Nederlandse titel',
+        'title_en' => 'English title',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    expect($blogPost->featured_image)->toBe(CreateBlogPost::PLACEHOLDER_FEATURED_IMAGE);
+});
+
+it('stores the provided featured image', function () {
+    $blogPost = CreateBlogPost::run([
+        'title_nl' => 'Nederlandse titel',
+        'title_en' => 'English title',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+        'featured_image' => 'blog/hero.jpg',
+    ]);
+
+    expect($blogPost->featured_image)->toBe('blog/hero.jpg');
+});

--- a/tests/Feature/Actions/CreateBlogPostTest.php
+++ b/tests/Feature/Actions/CreateBlogPostTest.php
@@ -1,14 +1,23 @@
 <?php
 
 use App\Actions\CreateBlogPost;
+use App\Data\CreateBlogPostData;
 use App\Models\BlogPost;
 
-it('creates a blog post as a draft', function () {
-    $blogPost = CreateBlogPost::run([
+function createBlogPost(array $attributes = []): BlogPost
+{
+    return CreateBlogPost::run(CreateBlogPostData::from(array_merge([
         'title_nl' => 'Nederlandse titel',
         'title_en' => 'English title',
         'content_nl' => '<p>Inhoud</p>',
         'content_en' => '<p>Content</p>',
+    ], $attributes)));
+}
+
+it('creates a blog post as a draft', function () {
+    $blogPost = createBlogPost([
+        'title_nl' => 'Nederlandse titel',
+        'title_en' => 'English title',
     ]);
 
     expect($blogPost)->toBeInstanceOf(BlogPost::class)
@@ -18,12 +27,7 @@ it('creates a blog post as a draft', function () {
 });
 
 it('generates a slug from the dutch title when none is provided', function () {
-    $blogPost = CreateBlogPost::run([
-        'title_nl' => 'Mijn Eerste Post',
-        'title_en' => 'My First Post',
-        'content_nl' => '<p>Inhoud</p>',
-        'content_en' => '<p>Content</p>',
-    ]);
+    $blogPost = createBlogPost(['title_nl' => 'Mijn Eerste Post']);
 
     expect($blogPost->slug)->toBe('mijn-eerste-post');
 });
@@ -31,47 +35,36 @@ it('generates a slug from the dutch title when none is provided', function () {
 it('appends a suffix when the generated slug already exists', function () {
     BlogPost::factory()->create(['slug' => 'mijn-eerste-post']);
 
-    $blogPost = CreateBlogPost::run([
-        'title_nl' => 'Mijn Eerste Post',
-        'title_en' => 'My First Post',
-        'content_nl' => '<p>Inhoud</p>',
-        'content_en' => '<p>Content</p>',
-    ]);
+    $blogPost = createBlogPost(['title_nl' => 'Mijn Eerste Post']);
 
     expect($blogPost->slug)->toBe('mijn-eerste-post-2');
 });
 
 it('uses the provided slug when given', function () {
-    $blogPost = CreateBlogPost::run([
-        'title_nl' => 'Nederlandse titel',
-        'title_en' => 'English title',
-        'content_nl' => '<p>Inhoud</p>',
-        'content_en' => '<p>Content</p>',
-        'slug' => 'custom-slug',
-    ]);
+    $blogPost = createBlogPost(['slug' => 'custom-slug']);
 
     expect($blogPost->slug)->toBe('custom-slug');
 });
 
 it('falls back to the placeholder featured image when none is provided', function () {
-    $blogPost = CreateBlogPost::run([
-        'title_nl' => 'Nederlandse titel',
-        'title_en' => 'English title',
-        'content_nl' => '<p>Inhoud</p>',
-        'content_en' => '<p>Content</p>',
-    ]);
+    $blogPost = createBlogPost();
 
     expect($blogPost->featured_image)->toBe(CreateBlogPost::PLACEHOLDER_FEATURED_IMAGE);
 });
 
 it('stores the provided featured image', function () {
-    $blogPost = CreateBlogPost::run([
-        'title_nl' => 'Nederlandse titel',
-        'title_en' => 'English title',
-        'content_nl' => '<p>Inhoud</p>',
-        'content_en' => '<p>Content</p>',
-        'featured_image' => 'blog/hero.jpg',
-    ]);
+    $blogPost = createBlogPost(['featured_image' => 'blog/hero.jpg']);
 
     expect($blogPost->featured_image)->toBe('blog/hero.jpg');
+});
+
+it('sanitizes dangerous html in the content', function () {
+    $blogPost = createBlogPost([
+        'content_nl' => '<p>Veilig</p><script>alert("xss")</script>',
+        'content_en' => '<p>Safe</p><a href="#" onclick="alert(1)">link</a>',
+    ]);
+
+    expect($blogPost->content_nl)->not->toContain('<script>')
+        ->and($blogPost->content_nl)->toContain('Veilig')
+        ->and($blogPost->content_en)->not->toContain('onclick');
 });

--- a/tests/Feature/Actions/GenerateUniqueBlogPostSlugTest.php
+++ b/tests/Feature/Actions/GenerateUniqueBlogPostSlugTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Actions\GenerateUniqueBlogPostSlug;
+use App\Models\BlogPost;
+
+it('slugifies the source string', function () {
+    expect(GenerateUniqueBlogPostSlug::run('Mijn Mooie Titel'))->toBe('mijn-mooie-titel');
+});
+
+it('appends an incrementing suffix on collisions', function () {
+    BlogPost::factory()->create(['slug' => 'titel']);
+    BlogPost::factory()->create(['slug' => 'titel-2']);
+
+    expect(GenerateUniqueBlogPostSlug::run('Titel'))->toBe('titel-3');
+});
+
+it('ignores the given post when checking uniqueness', function () {
+    $blogPost = BlogPost::factory()->create(['slug' => 'titel']);
+
+    expect(GenerateUniqueBlogPostSlug::run('Titel', $blogPost->id))->toBe('titel');
+});

--- a/tests/Feature/Actions/GetAllBlogPostsTest.php
+++ b/tests/Feature/Actions/GetAllBlogPostsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Actions\GetAllBlogPosts;
+use App\Models\BlogPost;
+
+it('returns published and draft posts when status is all', function () {
+    BlogPost::factory()->create();
+    BlogPost::factory()->draft()->create();
+
+    $paginator = GetAllBlogPosts::run(status: 'all');
+
+    expect($paginator->total())->toBe(2);
+});
+
+it('returns only published posts when status is published', function () {
+    BlogPost::factory()->create();
+    BlogPost::factory()->draft()->create();
+    BlogPost::factory()->scheduled()->create();
+
+    $paginator = GetAllBlogPosts::run(status: 'published');
+
+    expect($paginator->total())->toBe(1);
+});
+
+it('treats scheduled posts as drafts', function () {
+    BlogPost::factory()->create();
+    BlogPost::factory()->draft()->create();
+    BlogPost::factory()->scheduled()->create();
+
+    $paginator = GetAllBlogPosts::run(status: 'draft');
+
+    expect($paginator->total())->toBe(2);
+});
+
+it('filters by search term across both titles', function () {
+    BlogPost::factory()->create(['title_nl' => 'Laravel tips', 'title_en' => 'Something else']);
+    BlogPost::factory()->create(['title_nl' => 'Iets anders', 'title_en' => 'Laravel tricks']);
+    BlogPost::factory()->create(['title_nl' => 'Niet relevant', 'title_en' => 'Not relevant']);
+
+    $paginator = GetAllBlogPosts::run(search: 'Laravel');
+
+    expect($paginator->total())->toBe(2);
+});
+
+it('paginates the results', function () {
+    BlogPost::factory()->count(5)->create();
+
+    $paginator = GetAllBlogPosts::run(perPage: 2, page: 1);
+
+    expect($paginator->total())->toBe(5)
+        ->and($paginator->perPage())->toBe(2)
+        ->and($paginator->lastPage())->toBe(3)
+        ->and($paginator->items())->toHaveCount(2);
+});

--- a/tests/Feature/Actions/PublishBlogPostTest.php
+++ b/tests/Feature/Actions/PublishBlogPostTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Actions\PublishBlogPost;
+use App\Models\BlogPost;
+use Illuminate\Support\Carbon;
+
+it('publishes a draft immediately when no date is given', function () {
+    Carbon::setTestNow('2026-07-08 12:00:00');
+    $blogPost = BlogPost::factory()->draft()->create();
+
+    PublishBlogPost::run($blogPost);
+
+    expect($blogPost->refresh()->published_at->toDateTimeString())->toBe('2026-07-08 12:00:00')
+        ->and($blogPost->isPublished())->toBeTrue();
+});
+
+it('schedules publication for a future date', function () {
+    Carbon::setTestNow('2026-07-08 12:00:00');
+    $blogPost = BlogPost::factory()->draft()->create();
+    $future = Carbon::parse('2026-07-15 09:00:00');
+
+    PublishBlogPost::run($blogPost, $future);
+
+    $blogPost->refresh();
+
+    expect($blogPost->published_at->toDateTimeString())->toBe('2026-07-15 09:00:00')
+        ->and($blogPost->isPublished())->toBeFalse();
+});

--- a/tests/Feature/Actions/UnpublishBlogPostTest.php
+++ b/tests/Feature/Actions/UnpublishBlogPostTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Actions\UnpublishBlogPost;
+use App\Models\BlogPost;
+
+it('reverts a published post to a draft', function () {
+    $blogPost = BlogPost::factory()->create(['published_at' => now()->subDay()]);
+
+    UnpublishBlogPost::run($blogPost);
+
+    $blogPost->refresh();
+
+    expect($blogPost->published_at)->toBeNull()
+        ->and($blogPost->isPublished())->toBeFalse();
+});

--- a/tests/Feature/Actions/UpdateBlogPostTest.php
+++ b/tests/Feature/Actions/UpdateBlogPostTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\UpdateBlogPost;
+use App\Data\UpdateBlogPostData;
 use App\Models\BlogPost;
 
 it('only updates the fields that are provided', function () {
@@ -10,9 +11,9 @@ it('only updates the fields that are provided', function () {
         'content_nl' => '<p>Origineel</p>',
     ]);
 
-    UpdateBlogPost::run($blogPost, [
+    UpdateBlogPost::run($blogPost, UpdateBlogPostData::from([
         'title_nl' => 'Aangepast NL',
-    ]);
+    ]));
 
     $blogPost->refresh();
 
@@ -24,7 +25,7 @@ it('only updates the fields that are provided', function () {
 it('can clear a nullable excerpt', function () {
     $blogPost = BlogPost::factory()->create(['excerpt_nl' => 'Bestaand excerpt']);
 
-    UpdateBlogPost::run($blogPost, ['excerpt_nl' => null]);
+    UpdateBlogPost::run($blogPost, UpdateBlogPostData::from(['excerpt_nl' => null]));
 
     expect($blogPost->refresh()->excerpt_nl)->toBeNull();
 });
@@ -33,7 +34,7 @@ it('regenerates a unique slug when the slug is updated', function () {
     BlogPost::factory()->create(['slug' => 'bestaande-slug']);
     $blogPost = BlogPost::factory()->create(['slug' => 'oude-slug']);
 
-    UpdateBlogPost::run($blogPost, ['slug' => 'Bestaande Slug']);
+    UpdateBlogPost::run($blogPost, UpdateBlogPostData::from(['slug' => 'Bestaande Slug']));
 
     expect($blogPost->refresh()->slug)->toBe('bestaande-slug-2');
 });
@@ -41,7 +42,18 @@ it('regenerates a unique slug when the slug is updated', function () {
 it('keeps its own slug when updating with an unchanged slug', function () {
     $blogPost = BlogPost::factory()->create(['slug' => 'mijn-slug']);
 
-    UpdateBlogPost::run($blogPost, ['slug' => 'mijn-slug']);
+    UpdateBlogPost::run($blogPost, UpdateBlogPostData::from(['slug' => 'mijn-slug']));
 
     expect($blogPost->refresh()->slug)->toBe('mijn-slug');
+});
+
+it('sanitizes dangerous html when updating content', function () {
+    $blogPost = BlogPost::factory()->create();
+
+    UpdateBlogPost::run($blogPost, UpdateBlogPostData::from([
+        'content_nl' => '<p>Veilig</p><script>alert("xss")</script>',
+    ]));
+
+    expect($blogPost->refresh()->content_nl)->not->toContain('<script>')
+        ->and($blogPost->content_nl)->toContain('Veilig');
 });

--- a/tests/Feature/Actions/UpdateBlogPostTest.php
+++ b/tests/Feature/Actions/UpdateBlogPostTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Actions\UpdateBlogPost;
+use App\Models\BlogPost;
+
+it('only updates the fields that are provided', function () {
+    $blogPost = BlogPost::factory()->create([
+        'title_nl' => 'Origineel NL',
+        'title_en' => 'Original EN',
+        'content_nl' => '<p>Origineel</p>',
+    ]);
+
+    UpdateBlogPost::run($blogPost, [
+        'title_nl' => 'Aangepast NL',
+    ]);
+
+    $blogPost->refresh();
+
+    expect($blogPost->title_nl)->toBe('Aangepast NL')
+        ->and($blogPost->title_en)->toBe('Original EN')
+        ->and($blogPost->content_nl)->toBe('<p>Origineel</p>');
+});
+
+it('can clear a nullable excerpt', function () {
+    $blogPost = BlogPost::factory()->create(['excerpt_nl' => 'Bestaand excerpt']);
+
+    UpdateBlogPost::run($blogPost, ['excerpt_nl' => null]);
+
+    expect($blogPost->refresh()->excerpt_nl)->toBeNull();
+});
+
+it('regenerates a unique slug when the slug is updated', function () {
+    BlogPost::factory()->create(['slug' => 'bestaande-slug']);
+    $blogPost = BlogPost::factory()->create(['slug' => 'oude-slug']);
+
+    UpdateBlogPost::run($blogPost, ['slug' => 'Bestaande Slug']);
+
+    expect($blogPost->refresh()->slug)->toBe('bestaande-slug-2');
+});
+
+it('keeps its own slug when updating with an unchanged slug', function () {
+    $blogPost = BlogPost::factory()->create(['slug' => 'mijn-slug']);
+
+    UpdateBlogPost::run($blogPost, ['slug' => 'mijn-slug']);
+
+    expect($blogPost->refresh()->slug)->toBe('mijn-slug');
+});

--- a/tests/Feature/Console/IssueBlogTokenCommandTest.php
+++ b/tests/Feature/Console/IssueBlogTokenCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\User;
+use Laravel\Sanctum\PersonalAccessToken;
+
+it('creates the agent user and issues a token with blog abilities', function () {
+    $this->artisan('mcp:issue-blog-token')
+        ->assertSuccessful();
+
+    $user = User::where('email', 'agents@mecctech-solutions.nl')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('MCP Agent');
+
+    $token = PersonalAccessToken::where('tokenable_id', $user->id)->first();
+
+    expect($token->name)->toBe('claude-code')
+        ->and($token->abilities)->toContain('blog:read', 'blog:write');
+});
+
+it('reuses an existing user instead of creating a duplicate', function () {
+    $existing = User::factory()->create(['email' => 'agents@mecctech-solutions.nl']);
+
+    $this->artisan('mcp:issue-blog-token')->assertSuccessful();
+
+    expect(User::where('email', 'agents@mecctech-solutions.nl')->count())->toBe(1)
+        ->and(PersonalAccessToken::where('tokenable_id', $existing->id)->count())->toBe(1);
+});
+
+it('accepts a custom email, name and token label', function () {
+    $this->artisan('mcp:issue-blog-token', [
+        '--email' => 'bot@example.com',
+        '--name' => 'Custom Bot',
+        '--token-name' => 'ci-runner',
+    ])->assertSuccessful();
+
+    $user = User::where('email', 'bot@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('Custom Bot');
+
+    expect(PersonalAccessToken::where('tokenable_id', $user->id)->first()->name)->toBe('ci-runner');
+});

--- a/tests/Feature/Mcp/BlogServerTest.php
+++ b/tests/Feature/Mcp/BlogServerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\BlogPost;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+function callMcpTool(TestCase $test, string $name, array $arguments = [])
+{
+    return $test->postJson('mcp/blog', [
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $name,
+            'arguments' => $arguments,
+        ],
+    ]);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function decodeToolResult($response): array
+{
+    return json_decode((string) $response->json('result.content.0.text'), true);
+}
+
+it('rejects unauthenticated requests', function () {
+    $response = $this->postJson('mcp/blog', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'initialize',
+        'params' => [],
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('creates a blog post through the create tool', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:write', 'blog:read']);
+
+    $response = callMcpTool($this, 'create-blog-post', [
+        'title_nl' => 'Nieuwe post',
+        'title_en' => 'New post',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    $response->assertOk();
+    expect($response->json('result.isError'))->toBeFalse();
+
+    $data = decodeToolResult($response);
+
+    expect($data['title_nl'])->toBe('Nieuwe post')
+        ->and($data['published_at'])->toBeNull();
+
+    $this->assertDatabaseHas(BlogPost::class, [
+        'title_nl' => 'Nieuwe post',
+        'title_en' => 'New post',
+        'published_at' => null,
+    ]);
+});
+
+it('lists blog posts including drafts through the list tool', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:read']);
+    BlogPost::factory()->create();
+    BlogPost::factory()->draft()->create();
+
+    $response = callMcpTool($this, 'list-blog-posts', ['status' => 'all']);
+
+    $response->assertOk();
+    $data = decodeToolResult($response);
+
+    expect($data['total'])->toBe(2);
+});
+
+it('publishes a blog post through the publish tool', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:write']);
+    $blogPost = BlogPost::factory()->draft()->create();
+
+    $response = callMcpTool($this, 'publish-blog-post', ['id' => $blogPost->id]);
+
+    $response->assertOk();
+    expect($response->json('result.isError'))->toBeFalse()
+        ->and($blogPost->refresh()->isPublished())->toBeTrue();
+});
+
+it('does not expose a delete tool', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:write', 'blog:read']);
+
+    $response = $this->postJson('mcp/blog', [
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'method' => 'tools/list',
+    ]);
+
+    $response->assertOk();
+
+    $toolNames = collect($response->json('result.tools'))->pluck('name');
+
+    expect($toolNames)->toContain(
+        'create-blog-post',
+        'update-blog-post',
+        'get-blog-post',
+        'list-blog-posts',
+        'publish-blog-post',
+        'unpublish-blog-post',
+    )->and($toolNames)->not->toContain('delete-blog-post');
+});
+
+it('blocks write tools when the token lacks the blog:write ability', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:read']);
+
+    $response = callMcpTool($this, 'create-blog-post', [
+        'title_nl' => 'Nieuwe post',
+        'title_en' => 'New post',
+        'content_nl' => '<p>Inhoud</p>',
+        'content_en' => '<p>Content</p>',
+    ]);
+
+    $response->assertOk();
+    expect($response->json('result.isError'))->toBeTrue();
+
+    $this->assertDatabaseMissing(BlogPost::class, ['title_nl' => 'Nieuwe post']);
+});
+
+it('returns a validation error when required fields are missing', function () {
+    Sanctum::actingAs(User::factory()->create(), ['blog:write', 'blog:read']);
+
+    $response = callMcpTool($this, 'create-blog-post', [
+        'title_nl' => 'Alleen NL titel',
+    ]);
+
+    $response->assertOk();
+    expect($response->json('result.isError'))->toBeTrue();
+});


### PR DESCRIPTION
## What

Adds a web-based **MCP server** (`laravel/mcp`) that lets agents manage blog posts, at `POST /mcp/blog`, behind `auth:sanctum`.

### Tools (6)
| Tool | Purpose |
|------|---------|
| `create-blog-post` | Create a draft; both NL + EN required; auto slug; placeholder image |
| `update-blog-post` | Partial (patch) update of content fields only |
| `get-blog-post` | Fetch one post by id (incl. drafts) |
| `list-blog-posts` | Paginated list with `search` + `status` filter (incl. drafts) |
| `publish-blog-post` | Publish now, or schedule via future `published_at` |
| `unpublish-blog-post` | Revert to draft |

Deleting posts is intentionally **not** supported.

## Why / design decisions
- **Web transport + Sanctum**: reuses existing `HasApiTokens`; the server sits behind `auth:sanctum`. Optional token abilities `blog:read` / `blog:write` allow read-only agent tokens.
- **Shared Action classes** (`App\Actions`, `AsAction`) hold the logic (slug generation, placeholder default, publish/unpublish); the MCP tools are thin wrappers that validate, authorize, and return `BlogPostData`. Keeps logic reusable and unit-testable.
- **Publishing is a separate concern** from editing: `update` never touches `published_at`.
- Agents supply both languages (no auto-translation); slug is generated uniquely from `title_nl` when omitted; `featured_image` falls back to a placeholder so an editor can set the real hero image in Filament.

## Tests
40 tests, 72 assertions — all green; PHPStan (level 8) clean on the new code.
- Action tests: slug uniqueness, placeholder default, patch semantics, publish/unpublish, list filtering & pagination.
- MCP HTTP tests: unauthenticated rejection, tool calls mutating the DB, token-ability enforcement, validation errors, and that no delete tool is exposed.

## Reviewer notes
- The installed `laravel/mcp` (v0.1.1) HTTP transport is **stateless** — `initialize` returns no `Mcp-Session-Id`, so each request stands alone (differs from the `main`-branch docs). Tests reflect this.
- No service-account user/token is seeded (environment-specific). Create one with `User::...->createToken('mcp-agent', ['blog:write','blog:read'])` and pass it as a Bearer token. Happy to add an artisan command/seeder if wanted.
- `laravel/mcp` was added to composer (approved as the goal of this work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)