### PR TITLE
Add outreach-per-day dashboard chart widget

### DIFF
--- a/app/Actions/CountOutreachPerDay.php
+++ b/app/Actions/CountOutreachPerDay.php
@@ -8,6 +8,7 @@ use App\Models\OutreachAttempt;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
 
 class CountOutreachPerDay
 {
@@ -36,10 +37,11 @@ class CountOutreachPerDay
                 $windowEnd->copy()->utc(),
             ])
             ->get()
-            ->groupBy(fn (OutreachAttempt $attempt): string => $attempt->sent_at
-                ->copy()
-                ->setTimezone(self::TIMEZONE)
-                ->toDateString())
+            ->groupBy(function (OutreachAttempt $attempt): string {
+                $sentAt = $attempt->sent_at ?? throw new RuntimeException('A sent outreach attempt must have a sent_at timestamp.');
+
+                return $sentAt->copy()->setTimezone(self::TIMEZONE)->toDateString();
+            })
             ->map
             ->count();
 

--- a/app/Actions/CountOutreachPerDay.php
+++ b/app/Actions/CountOutreachPerDay.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Actions;
+
+use App\Builders\OutreachAttemptBuilder;
+use App\Data\DailyOutreachCountData;
+use App\Models\OutreachAttempt;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CountOutreachPerDay
+{
+    use AsAction;
+
+    public const TIMEZONE = 'Europe/Amsterdam';
+
+    public const DEFAULT_DAYS = 30;
+
+    /**
+     * Grouping happens in PHP against Amsterdam-local midnights because the
+     * database stores sent_at in UTC, so an evening outreach would otherwise
+     * land on the wrong calendar day.
+     *
+     * @return Collection<int, DailyOutreachCountData>
+     */
+    public function handle(int $days = self::DEFAULT_DAYS): Collection
+    {
+        $windowStart = Carbon::now(self::TIMEZONE)->startOfDay()->subDays($days - 1);
+        $windowEnd = Carbon::now(self::TIMEZONE)->endOfDay();
+
+        $countsByDate = OutreachAttempt::query()
+            ->sent()
+            ->whereBetween(OutreachAttemptBuilder::SENT_AT, [
+                $windowStart->copy()->utc(),
+                $windowEnd->copy()->utc(),
+            ])
+            ->get()
+            ->groupBy(fn (OutreachAttempt $attempt): string => $attempt->sent_at
+                ->copy()
+                ->setTimezone(self::TIMEZONE)
+                ->toDateString())
+            ->map
+            ->count();
+
+        return Collection::make(range(0, $days - 1))
+            ->map(function (int $offset) use ($windowStart, $countsByDate): DailyOutreachCountData {
+                $date = $windowStart->copy()->addDays($offset);
+
+                return new DailyOutreachCountData(
+                    date: $date,
+                    count: $countsByDate->get($date->toDateString(), 0),
+                );
+            });
+    }
+}

--- a/app/Data/DailyOutreachCountData.php
+++ b/app/Data/DailyOutreachCountData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Data;
+
+use Illuminate\Support\Carbon;
+use Spatie\LaravelData\Data;
+
+class DailyOutreachCountData extends Data
+{
+    public function __construct(
+        public Carbon $date,
+        public int $count,
+    ) {}
+}

--- a/app/Filament/Widgets/OutreachPerDayChart.php
+++ b/app/Filament/Widgets/OutreachPerDayChart.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Actions\CountOutreachPerDay;
+use App\Data\DailyOutreachCountData;
+use Filament\Widgets\ChartWidget;
+
+class OutreachPerDayChart extends ChartWidget
+{
+    protected const BRAND_COLOR = '#e30613';
+
+    protected const LABEL_DATE_FORMAT = 'd M';
+
+    protected static ?string $heading = 'Outreach per dag';
+
+    protected static ?string $description = 'Verstuurde outreach over de laatste 30 dagen';
+
+    protected int|string|array $columnSpan = 'full';
+
+    /**
+     * @return array{datasets: array<int, array<string, mixed>>, labels: array<int, string>}
+     */
+    protected function getData(): array
+    {
+        $daily = CountOutreachPerDay::run();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Verstuurd',
+                    'data' => $daily->pluck('count')->all(),
+                    'backgroundColor' => self::BRAND_COLOR,
+                ],
+            ],
+            'labels' => $daily
+                ->map(fn (DailyOutreachCountData $day): string => $day->date->translatedFormat(self::LABEL_DATE_FORMAT))
+                ->all(),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -43,6 +43,10 @@ excerpt_en: string | null;
 slug: string | null;
 featured_image: string | null;
 };
+export type DailyOutreachCountData = {
+date: any;
+count: number;
+};
 export type ImageData = {
 full_url: string;
 url: string;

--- a/tests/Feature/Actions/CountOutreachPerDayTest.php
+++ b/tests/Feature/Actions/CountOutreachPerDayTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Actions\CountOutreachPerDay;
+use App\Models\OutreachAttempt;
+use Illuminate\Support\Carbon;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-21 12:00:00');
+});
+
+it('returns one zero-filled bucket per day in the window', function () {
+    $daily = CountOutreachPerDay::run();
+
+    expect($daily)->toHaveCount(CountOutreachPerDay::DEFAULT_DAYS)
+        ->and($daily->last()->date->toDateString())->toBe('2026-07-21')
+        ->and($daily->first()->date->toDateString())->toBe('2026-06-22')
+        ->and($daily->sum('count'))->toBe(0);
+});
+
+it('counts sent attempts on their Amsterdam calendar day', function () {
+    OutreachAttempt::factory()->create(['sent_at' => '2026-07-21 09:00:00']);
+    OutreachAttempt::factory()->create(['sent_at' => '2026-07-20 09:00:00']);
+    OutreachAttempt::factory()->create(['sent_at' => '2026-07-20 15:00:00']);
+
+    $daily = CountOutreachPerDay::run()->keyBy(fn ($day) => $day->date->toDateString());
+
+    expect($daily->get('2026-07-21')->count)->toBe(1)
+        ->and($daily->get('2026-07-20')->count)->toBe(2)
+        ->and($daily->get('2026-06-30')->count)->toBe(0);
+});
+
+it('buckets by local midnight rather than the stored UTC day', function () {
+    OutreachAttempt::factory()->create(['sent_at' => '2026-07-20 23:30:00']);
+
+    $daily = CountOutreachPerDay::run()->keyBy(fn ($day) => $day->date->toDateString());
+
+    expect($daily->get('2026-07-21')->count)->toBe(1)
+        ->and($daily->get('2026-07-20')->count)->toBe(0);
+});
+
+it('ignores drafts and attempts outside the window', function () {
+    OutreachAttempt::factory()->draft()->create();
+    OutreachAttempt::factory()->create(['sent_at' => '2026-06-01 09:00:00']);
+
+    expect(CountOutreachPerDay::run()->sum('count'))->toBe(0);
+});
+
+it('counts follow-ups as their own outreach', function () {
+    $original = OutreachAttempt::factory()->create(['sent_at' => '2026-07-21 08:00:00']);
+    OutreachAttempt::factory()->followUpTo($original)->create(['sent_at' => '2026-07-21 16:00:00']);
+
+    $today = CountOutreachPerDay::run()->last();
+
+    expect($today->date->toDateString())->toBe('2026-07-21')
+        ->and($today->count)->toBe(2);
+});

--- a/tests/Feature/Filament/OutreachPerDayChartTest.php
+++ b/tests/Feature/Filament/OutreachPerDayChartTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Filament\Widgets\OutreachPerDayChart;
+use App\Models\OutreachAttempt;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-21 12:00:00');
+
+    $this->actingAs(User::factory()->create([
+        'email' => 'florismeccanici@tutanota.com',
+    ]));
+});
+
+it('renders the outreach chart widget', function () {
+    OutreachAttempt::factory()->create(['sent_at' => '2026-07-21 09:00:00']);
+
+    Livewire::test(OutreachPerDayChart::class)
+        ->assertOk()
+        ->assertSee('Outreach per dag');
+});


### PR DESCRIPTION
Adds a Filament dashboard ChartWidget that plots the number of sent
outreach attempts per day over the last 30 days. Counting lives in a
CountOutreachPerDay action that returns DailyOutreachCountData DTOs,
grouping sent_at on the Europe/Amsterdam day boundary and zero-filling
empty days, so the widget stays a thin presentation layer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BAmGX7ts9JgEQeVcApLdxY