### PR TITLE
Show the sent subject and message in the outreach history

### DIFF
--- a/app/Filament/Resources/ProspectResource/RelationManagers/OutreachAttemptsRelationManager.php
+++ b/app/Filament/Resources/ProspectResource/RelationManagers/OutreachAttemptsRelationManager.php
@@ -9,10 +9,12 @@ use App\Filament\Resources\ProspectResource;
 use App\Models\OutreachAttempt;
 use App\Models\Prospect;
 use Filament\Forms;
+use Filament\Infolists;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 
 /**
  * The outreach history for a single prospect: every attempt, newest first,
@@ -35,9 +37,14 @@ class OutreachAttemptsRelationManager extends RelationManager
                     ->dateTime()
                     ->placeholder('Draft')
                     ->sortable(),
+                Tables\Columns\TextColumn::make('subject')
+                    ->label('Subject')
+                    ->limit(40)
+                    ->tooltip(fn (OutreachAttempt $record): string => $record->subject),
                 Tables\Columns\TextColumn::make('outreachTemplate.name')
                     ->label('Template')
-                    ->placeholder('—'),
+                    ->placeholder('—')
+                    ->toggleable(),
                 Tables\Columns\IconColumn::make('follow_up_to_id')
                     ->label('Follow-up')
                     ->boolean()
@@ -68,11 +75,29 @@ class OutreachAttemptsRelationManager extends RelationManager
                     ->query(fn (OutreachAttemptBuilder $query): OutreachAttemptBuilder => $query->dueForFollowUp()),
             ])
             ->actions([
+                static::viewMessageAction(),
                 static::recordOutcomeAction(),
                 static::followUpAction(),
             ])
             ->emptyStateHeading('No outreach yet')
             ->emptyStateDescription('Compose a first attempt from the prospect list.');
+    }
+
+    protected static function viewMessageAction(): Tables\Actions\Action
+    {
+        return Tables\Actions\ViewAction::make('viewMessage')
+            ->label('View message')
+            ->icon('heroicon-o-envelope-open')
+            ->modalHeading('Message sent')
+            ->infolist([
+                Infolists\Components\TextEntry::make('subject')
+                    ->label('Subject'),
+                Infolists\Components\TextEntry::make('body')
+                    ->label('Message')
+                    ->html()
+                    ->formatStateUsing(fn (string $state): HtmlString => new HtmlString(nl2br(e($state))))
+                    ->columnSpanFull(),
+            ]);
     }
 
     /**

--- a/tests/Feature/Filament/OutreachAttemptsRelationManagerTest.php
+++ b/tests/Feature/Filament/OutreachAttemptsRelationManagerTest.php
@@ -92,3 +92,17 @@ it('creates a follow-up attempt pointing at the original with the same prospect'
         ->sent_at->not->toBeNull()
         ->subject->toBe('Following up on my earlier note');
 });
+
+it('shows the sent subject in the table and the full message in the view modal', function () {
+    $prospect = Prospect::factory()->create();
+    $attempt = OutreachAttempt::factory()->for($prospect)->sentDaysAgo(2)->create([
+        'subject' => 'Laravel developer voor jullie team',
+        'body' => "Hoi Jan,\n\nIk zag jullie vacature.",
+    ]);
+
+    relationManager($prospect)
+        ->assertTableColumnStateSet('subject', 'Laravel developer voor jullie team', $attempt)
+        ->mountTableAction('viewMessage', $attempt)
+        ->assertSee('Laravel developer voor jullie team')
+        ->assertSee('Ik zag jullie vacature.');
+});


### PR DESCRIPTION
## What

The prospect's **Outreach history** table now shows what was actually sent:

- **Subject** column, truncated at 40 chars with the full subject in a tooltip.
- **View message** row action opening a modal with the subject and the full body, line breaks preserved.
- **Template** column is now `toggleable` so the row stays readable with the extra column.

## Why

The table only showed *when* an attempt was sent and *which template* it used. The body is snapshotted per attempt and can be freely edited in the compose modal before sending, so the template name is not a reliable stand-in for the actual message — there was no way to look back at what went out.

## Notes for the reviewer

- The body is plain text (composed in a `Textarea`), so the modal renders it via `nl2br(e($state))` behind `->html()` to keep line breaks. Input is escaped before the `nl2br`.
- Covered by a new test in `tests/Feature/Filament/OutreachAttemptsRelationManagerTest.php`; the whole file passes (5 tests) and PHPStan is clean on the changed file. Pint was not run — `vendor/bin/pint` is not installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)